### PR TITLE
Fix namespace

### DIFF
--- a/lib/coprl/presenters/plugins/meta_pixel.rb
+++ b/lib/coprl/presenters/plugins/meta_pixel.rb
@@ -10,7 +10,7 @@ module Coprl
       module MetaPixel
         module DSLComponents
           def meta_pixel(pixel_id, **attributes, &block)
-            self << MetaPixel::Component.new(
+            self << Components::MetaPixelComponent.new(
               pixel_id,
               **attributes,
               parent: self,
@@ -19,7 +19,7 @@ module Coprl
           end
 
           def create_meta_pixel_event(event_name, event_data, **attributes, &block)
-            self << MetaPixel::Event.new(
+            self << Components::MetaPixelEvent.new(
               event_name,
               event_data,
               **attributes,

--- a/lib/coprl/presenters/plugins/meta_pixel/components/meta_pixel_component.rb
+++ b/lib/coprl/presenters/plugins/meta_pixel/components/meta_pixel_component.rb
@@ -4,13 +4,15 @@ module Coprl
   module Presenters
     module Plugins
       module MetaPixel
-        class MetaPixelComponent < DSL::Components::Base
-          attr_reader :pixel_id
+        module Components
+          class MetaPixelComponent < DSL::Components::Base
+            attr_reader :pixel_id
 
-          def initialize(pixel_id, **attributes, &block)
-            @pixel_id = pixel_id
-            super(type: :meta_pixel_tag, **attributes, &block)
-            expand!
+            def initialize(pixel_id, **attributes, &block)
+              @pixel_id = pixel_id
+              super(type: :meta_pixel_tag, **attributes, &block)
+              expand!
+            end
           end
         end
       end

--- a/lib/coprl/presenters/plugins/meta_pixel/components/meta_pixel_event.rb
+++ b/lib/coprl/presenters/plugins/meta_pixel/components/meta_pixel_event.rb
@@ -4,14 +4,16 @@ module Coprl
   module Presenters
     module Plugins
       module MetaPixel
-        class MetaPixelEvent < DSL::Components::Base
-          attr_reader :event_name, :event_data
+        module Components
+          class MetaPixelEvent < DSL::Components::Base
+            attr_reader :event_name, :event_data
 
-          def initialize(event_name, event_data, **attribs_, &block)
-            super(type: :meta_pixel_event, **attribs_, &block)
-            @event_name = event_name
-            @event_data = event_data
-            expand!
+            def initialize(event_name, event_data, **attribs_, &block)
+              super(type: :meta_pixel_event, **attribs_, &block)
+              @event_name = event_name
+              @event_data = event_data
+              expand!
+            end
           end
         end
       end


### PR DESCRIPTION
The classes in the `components` directory did not belong to the `Components` module.